### PR TITLE
add Swift

### DIFF
--- a/Prolangle/Languages/Swift.cs
+++ b/Prolangle/Languages/Swift.cs
@@ -1,0 +1,24 @@
+using Prolangle.Languages.Framework;
+
+namespace Prolangle.Languages;
+
+public class Swift : BaseLanguage
+{
+	public override Guid Id { get; } = Guid.NewGuid();
+	public override string Name { get; } = "Swift";
+	public override TypeSystem Typing { get; } = TypeSystem.Static | TypeSystem.Strong | TypeSystem.Inferred;
+	public override bool Compiled { get; } = true;
+	public override bool GarbageCollected { get; } = true;
+	public override SyntaxStyle SyntaxStyle { get; } = SyntaxStyle.C;
+
+	public override Applications KnownForBuilding { get; } = Applications.Apple | Applications.Mobile |
+	                                                         Applications.Client | Applications.Desktop |
+	                                                         Applications.System;
+
+	public override Paradigms Paradigms { get; } = Paradigms.ObjectOriented | Paradigms.Functional |
+	                                               Paradigms.Imperative | Paradigms.Declarative | Paradigms.Concurrent |
+	                                               Paradigms.EventDriven | Paradigms.Reflective;
+
+	public override double? TiobeRating { get; } = 0.82;
+	public override int AppearanceYear { get; } = 2014;
+}

--- a/Prolangle/Services/LanguagesProvider.cs
+++ b/Prolangle/Services/LanguagesProvider.cs
@@ -23,6 +23,7 @@ public class LanguagesProvider
 			yield return new Php();
 			yield return new Python();
 			yield return new Step();
+			yield return new Swift();
 		}
 	}
 }


### PR DESCRIPTION
I'm unsure about the `KnownForBuilding` and `Paradigms` values. For example, is an object-oriented language also always procedural?

Wikipedia also suggests "protocol-oriented" and "block structured"; maybe these need to be added to the enum.