### PR TITLE
added Objective-C

### DIFF
--- a/Prolangle/Languages/Framework/SyntaxStyle.cs
+++ b/Prolangle/Languages/Framework/SyntaxStyle.cs
@@ -23,6 +23,11 @@ public enum SyntaxStyle
 	Pascal,
 	Perl,
 
+	[Description("In Smalltalk syntax, you start with the receiver of a " +
+	             "message (an object), then continue with the message to " +
+	             "send to it.")]
+	Smalltalk,
+
 	[Description("In the XML or SGML syntax style, tags use angular brackets " +
 	             "< >, and can be nested, to form a document tree.")]
 	[Display(Name = "XML")]

--- a/Prolangle/Languages/ObjectiveC.cs
+++ b/Prolangle/Languages/ObjectiveC.cs
@@ -1,0 +1,26 @@
+using Prolangle.Languages.Framework;
+
+namespace Prolangle.Languages;
+
+public class ObjectiveC : BaseLanguage
+{
+	public override Guid Id { get; } = Guid.NewGuid();
+	public override string Name { get; } = "Objective-C";
+	public override TypeSystem Typing { get; } = TypeSystem.Dynamic | TypeSystem.Strong;
+	public override bool Compiled { get; } = true;
+
+	public override MemoryManagement MemoryManagement { get; } =
+		MemoryManagement.GarbageCollection; // TODO change after #44 merge
+
+	public override SyntaxStyle SyntaxStyle { get; } = SyntaxStyle.Smalltalk;
+
+	public override Applications KnownForBuilding { get; } = Applications.Apple | Applications.Mobile |
+	                                                         Applications.Client | Applications.Desktop |
+	                                                         Applications.System;
+
+	public override Paradigms Paradigms { get; } =
+		Paradigms.ObjectOriented | Paradigms.EventDriven | Paradigms.Reflective;
+
+	public override double? TiobeRating { get; } = 0.43;
+	public override int AppearanceYear { get; } = 1984;
+}

--- a/Prolangle/Services/LanguagesProvider.cs
+++ b/Prolangle/Services/LanguagesProvider.cs
@@ -24,6 +24,7 @@ public class LanguagesProvider
 			yield return new Html();
 			yield return new Java();
 			yield return new Javascript();
+			yield return new ObjectiveC();
 			yield return new Pascal();
 			yield return new Perl();
 			yield return new Php();


### PR DESCRIPTION
What Progle says:

Language | Typed | Compiled | Garbage Collected | Syntax Style | Known For Building | Paradigms | GH Repos | Appearance Year
-- | -- | -- | -- | -- | -- | -- | -- | --
Objective-C | strong, static | compiled | garbage collected | C - like | mobile, apple | object oriented | 538.5k | 1984

* I disagree with `static`. Now, Objective-C is basically a mixed language of C with Smalltalk[^1] on top, but the Smalltalk portions are `dynamic`, and I think we should focus on those, because otherwise, it's just C.
* We should go with reference counting here. Waiting on #44.
* I've also introduced a new syntax style. If we're focusing on the non-C-parts, the syntax style is really nothing like C at all, e.g. `[myColor changeColorToRed:5.0 green:2.0 blue:6.0];`.

[^1]: as in, a Smalltalk-like language.
