### PR TITLE
Snippet highlighting

### DIFF
--- a/Prolangle/Components/CodeSnippet.razor
+++ b/Prolangle/Components/CodeSnippet.razor
@@ -1,0 +1,35 @@
+@implements IAsyncDisposable
+
+@inject IJSRuntime JS
+
+<pre class="snippet-game-code">
+	<code class="@Language">
+		@ChildContent
+	</code>
+</pre>
+
+@code {
+	private IJSObjectReference? jsModule;
+
+	[Parameter] public RenderFragment ChildContent { get; set; }
+	[Parameter] public string Language { get; set; } = "csharp";
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			    jsModule = await JS.InvokeAsync<IJSObjectReference>(
+			         "import", "./Components/CodeSnippet.razor.js");
+		}
+
+		await jsModule.InvokeVoidAsync("highlightSnippet", );
+	}
+
+	async ValueTask IAsyncDisposable.DisposeAsync()
+	{
+		if (jsModule is null )
+			return;
+
+		await jsModule.DisposeAsync();
+	}
+}

--- a/Prolangle/Components/CodeSnippet.razor
+++ b/Prolangle/Components/CodeSnippet.razor
@@ -1,6 +1,10 @@
+@using Prolangle.Languages.Framework
+
 @implements IAsyncDisposable
 
 @inject IJSRuntime JsRuntime
+
+@inject ILogger<CodeSnippet> Logger
 
 <pre class="snippet-game-code">
 	<code class="@Language" @ref="_codeElement">
@@ -15,20 +19,30 @@
 	public required RenderFragment ChildContent { get; set; }
 
 	[Parameter]
-	public string Language { get; set; } = "csharp";
+	public required ILanguage Language { get; set; }
 
 	ElementReference _codeElement;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
-		if (firstRender)
+		if (Language is ILanguageSupportsSyntaxHighlighting highlighteableLanguage)
 		{
-			_jsModule = await JsRuntime.InvokeAsync<IJSObjectReference>(
-				"import", "./Components/CodeSnippet.razor.js");
-		}
+			Logger.LogInformation("Preparing syntax highlighting for {Language}", Language.Name);
 
-		if (_jsModule is not null)
-			await _jsModule.InvokeVoidAsync("CodeSnippet.highlightSnippet", _codeElement);
+			if (firstRender)
+			{
+				_jsModule = await JsRuntime.InvokeAsync<IJSObjectReference>(
+					"import", "./Components/CodeSnippet.razor.js");
+			}
+
+			if (_jsModule is not null)
+				await _jsModule.InvokeVoidAsync("CodeSnippet.highlightSnippet",
+					_codeElement, highlighteableLanguage.HighlightJsIdentifier);
+		}
+		else
+		{
+			Logger.LogInformation("No syntax highlighting because {Language} does not support it", Language.Name);
+		}
 	}
 
 	async ValueTask IAsyncDisposable.DisposeAsync()
@@ -38,4 +52,5 @@
 
 		await _jsModule.DisposeAsync();
 	}
+
 }

--- a/Prolangle/Components/CodeSnippet.razor
+++ b/Prolangle/Components/CodeSnippet.razor
@@ -1,35 +1,41 @@
 @implements IAsyncDisposable
 
-@inject IJSRuntime JS
+@inject IJSRuntime JsRuntime
 
 <pre class="snippet-game-code">
-	<code class="@Language">
+	<code class="@Language" @ref="_codeElement">
 		@ChildContent
 	</code>
 </pre>
 
 @code {
-	private IJSObjectReference? jsModule;
+	private IJSObjectReference? _jsModule;
 
-	[Parameter] public RenderFragment ChildContent { get; set; }
-	[Parameter] public string Language { get; set; } = "csharp";
+	[Parameter]
+	public required RenderFragment ChildContent { get; set; }
+
+	[Parameter]
+	public string Language { get; set; } = "csharp";
+
+	ElementReference _codeElement;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		if (firstRender)
 		{
-			    jsModule = await JS.InvokeAsync<IJSObjectReference>(
-			         "import", "./Components/CodeSnippet.razor.js");
+			_jsModule = await JsRuntime.InvokeAsync<IJSObjectReference>(
+				"import", "./Components/CodeSnippet.razor.js");
 		}
 
-		await jsModule.InvokeVoidAsync("highlightSnippet", );
+		if (_jsModule is not null)
+			await _jsModule.InvokeVoidAsync("CodeSnippet.highlightSnippet", _codeElement);
 	}
 
 	async ValueTask IAsyncDisposable.DisposeAsync()
 	{
-		if (jsModule is null )
+		if (_jsModule is null)
 			return;
 
-		await jsModule.DisposeAsync();
+		await _jsModule.DisposeAsync();
 	}
 }

--- a/Prolangle/Components/CodeSnippet.razor.js
+++ b/Prolangle/Components/CodeSnippet.razor.js
@@ -1,6 +1,10 @@
 export class CodeSnippet
 {
-    static highlightSnippet(elem) {
+    static highlightSnippet(elem, languageIdentifier) {
+        hljs.configure({
+            languages: [ languageIdentifier ]
+        });
+
         hljs.highlightElement(elem);
     }
 }

--- a/Prolangle/Components/CodeSnippet.razor.js
+++ b/Prolangle/Components/CodeSnippet.razor.js
@@ -1,0 +1,6 @@
+export class CodeSnippet
+{
+    static highlight(elem) {
+        hljs.highlightBlock(elem);
+    }
+}

--- a/Prolangle/Components/CodeSnippet.razor.js
+++ b/Prolangle/Components/CodeSnippet.razor.js
@@ -1,6 +1,6 @@
 export class CodeSnippet
 {
-    static highlight(elem) {
-        hljs.highlightBlock(elem);
+    static highlightSnippet(elem) {
+        hljs.highlightElement(elem);
     }
 }

--- a/Prolangle/Languages/AppleScript.cs
+++ b/Prolangle/Languages/AppleScript.cs
@@ -2,11 +2,12 @@ using Prolangle.Languages.Framework;
 
 namespace Prolangle.Languages;
 
-public class AppleScript : BaseLanguage
+public class AppleScript : BaseLanguage, ILanguageSupportsSyntaxHighlighting
 {
 	public static AppleScript Instance { get; } = new();
 	public override Guid Id { get; } = Guid.NewGuid();
 	public override string Name { get; } = "AppleScript";
+	public string HighlightJsIdentifier { get; } = "applescript";
 	public override TypeSystem Typing { get; } = TypeSystem.Weak | TypeSystem.Dynamic;
 	public override bool Compiled { get; } = true;
 	public override MemoryManagement MemoryManagement { get; } = MemoryManagement.TracingGarbageCollection;

--- a/Prolangle/Languages/CSharp.cs
+++ b/Prolangle/Languages/CSharp.cs
@@ -2,11 +2,12 @@
 
 namespace Prolangle.Languages;
 
-public class CSharp : BaseLanguage
+public class CSharp : BaseLanguage, ILanguageSupportsSyntaxHighlighting
 {
 	public static CSharp Instance { get; } = new();
 	public override Guid Id { get; } = Guid.NewGuid();
 	public override string Name { get; } = "C#";
+	public string HighlightJsIdentifier { get; } = "csharp";
 
 	public override TypeSystem Typing { get; } = TypeSystem.Static | TypeSystem.Strong | TypeSystem.Dynamic |
 	                                             TypeSystem.Safe | TypeSystem.Nominal | TypeSystem.Inferred;

--- a/Prolangle/Languages/Framework/ILanguage.cs
+++ b/Prolangle/Languages/Framework/ILanguage.cs
@@ -22,3 +22,11 @@ public interface ILanguage
 
 	public int AppearanceYear { get; }
 }
+
+public interface ILanguageSupportsSyntaxHighlighting : ILanguage
+{
+	/// <summary>
+	/// The identifier, as listed at https://highlightjs.readthedocs.io/en/latest/supported-languages.html.
+	/// </summary>
+	public string HighlightJsIdentifier { get; }
+}

--- a/Prolangle/Languages/Php.cs
+++ b/Prolangle/Languages/Php.cs
@@ -2,11 +2,12 @@ using Prolangle.Languages.Framework;
 
 namespace Prolangle.Languages;
 
-public class Php : BaseLanguage
+public class Php : BaseLanguage, ILanguageSupportsSyntaxHighlighting
 {
 	public static Php Instance { get; } = new();
 	public override Guid Id { get; } = Guid.NewGuid();
 	public override string Name { get; } = "PHP";
+	public string HighlightJsIdentifier { get; } = "php";
 	public override TypeSystem Typing { get; } = TypeSystem.Dynamic | TypeSystem.Weak;
 	public override bool Compiled { get; } = false;
 	public override MemoryManagement MemoryManagement { get; } = MemoryManagement.ReferenceCounting;

--- a/Prolangle/Pages/Snippets.razor
+++ b/Prolangle/Pages/Snippets.razor
@@ -20,11 +20,7 @@ else
 	<LanguageSelection AvailableLanguages="@AvailableLanguages" OnLanguageSelected="@OnLanguageSelected"/>
 }
 
-<code>
-	<pre>
-        @_concealedSourceCode
-    </pre>
-</code>
+<CodeSnippet>@_concealedSourceCode</CodeSnippet>
 
 <div style="display: flex; flex-wrap: wrap; flex-direction: row; gap: 1em;">
 	@foreach (var language in RevealedLanguages)

--- a/Prolangle/Pages/Snippets.razor
+++ b/Prolangle/Pages/Snippets.razor
@@ -20,7 +20,7 @@ else
 	<LanguageSelection AvailableLanguages="@AvailableLanguages" OnLanguageSelected="@OnLanguageSelected"/>
 }
 
-<CodeSnippet>@_concealedSourceCode</CodeSnippet>
+<CodeSnippet Language="TargetLanguage!">@_concealedSourceCode</CodeSnippet>
 
 <div style="display: flex; flex-wrap: wrap; flex-direction: row; gap: 1em;">
 	@foreach (var language in RevealedLanguages)

--- a/Prolangle/Pages/Snippets.razor
+++ b/Prolangle/Pages/Snippets.razor
@@ -20,7 +20,10 @@ else
 	<LanguageSelection AvailableLanguages="@AvailableLanguages" OnLanguageSelected="@OnLanguageSelected"/>
 }
 
-<CodeSnippet Language="TargetLanguage!">@_concealedSourceCode</CodeSnippet>
+@if (_showSourceCode)
+{
+	<CodeSnippet Language="TargetLanguage!">@_concealedSourceCode</CodeSnippet>
+}
 
 <div style="display: flex; flex-wrap: wrap; flex-direction: row; gap: 1em;">
 	@foreach (var language in RevealedLanguages)
@@ -44,21 +47,23 @@ else
 	private ICodeSnippet? Snippet { get; set; }
 	private bool _won;
 
+	private bool _showSourceCode = false;
+
 	private SnippetRevealer? _snippetRevealer;
 
 	private string? _concealedSourceCode;
 
-	protected override void OnInitialized()
+	protected override async Task OnInitializedAsync()
 	{
 		TargetLanguage = GuessGame!.SnippetGameLanguage;
 		Snippet = LanguageSnippetProvider!.GetSnippet(TargetLanguage);
 
 		_snippetRevealer = new SnippetRevealer(GuessGame, Snippet.SourceCode, useJitter: true);
 
-		_concealedSourceCode = _snippetRevealer.RevealMore();
+		await UpdateConcealedSourceCode(_snippetRevealer!.RevealMore());
 	}
 
-	private void OnLanguageSelected(ILanguage language)
+	private async Task OnLanguageSelected(ILanguage language)
 	{
 		RevealedLanguages.Add(language);
 
@@ -69,13 +74,27 @@ else
 			_won = true;
 			_snippetRevealer!.Win();
 
-			_concealedSourceCode = Snippet!.SourceCode;
+			await UpdateConcealedSourceCode(Snippet!.SourceCode);
 		}
 		else
 		{
-			_concealedSourceCode = _snippetRevealer!.RevealMore();
+			await UpdateConcealedSourceCode(_snippetRevealer!.RevealMore());
 		}
 
+		StateHasChanged();
+	}
+
+	private async Task UpdateConcealedSourceCode(string newSourceCode)
+	{
+		_showSourceCode = false;
+		StateHasChanged();
+
+		// force Blazor to dispose the <CodeSnippet> component so JS gets cleaned up
+		await Task.Yield();
+
+		_concealedSourceCode = newSourceCode;
+
+		_showSourceCode = true;
 		StateHasChanged();
 	}
 }

--- a/Prolangle/wwwroot/index.html
+++ b/Prolangle/wwwroot/index.html
@@ -19,6 +19,8 @@
     <link href="_content/Blazorise.Bulma/blazorise.bulma.css" rel="stylesheet" />
     <link href="_content/Blazorise.Snackbar/blazorise.snackbar.css" rel="stylesheet" />
 
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+
     <link rel="stylesheet" href="css/app.css"/>
     <link href="Prolangle.styles.css" rel="stylesheet"/>
 </head>
@@ -41,6 +43,10 @@
     <script src="js/app.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/Blazored.Typeahead/blazored-typeahead.js"></script>
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/csharp.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/css.min.js"></script>
 
     <!-- TODO: remove comment around components we need -->
 <!--    <script src="_content/Blazorise/breakpoint.js?v=1.4.0.0" type="module"></script>-->


### PR DESCRIPTION
This technically works:

![image](https://github.com/ricardoboss/Prolangle/assets/20194/772ecdd7-6a85-4720-a88f-09e69155366b)

![image](https://github.com/ricardoboss/Prolangle/assets/20194/4ca6c1c6-447c-4ed8-9fde-97bad90f5195)

![image](https://github.com/ricardoboss/Prolangle/assets/20194/31a20ac0-76a1-4175-b1a2-cd0a38956276)

However, one weakness is that the highlighter doesn't get context from the concealed code. Progle even goes so far as to highlight the concealed characters. We can't do that with this design.

What we probably _should_ do instead is retrieve "what _would_ it have highlighted?" back, _then_ conceal it.