### PR TITLE
Hints

### DIFF
--- a/Prolangle/Components/LanguageMetadatum.razor
+++ b/Prolangle/Components/LanguageMetadatum.razor
@@ -1,3 +1,4 @@
+@using BlazorComponentUtilities
 @using System.Text
 @using Prolangle.Extensions
 @using Prolangle.Languages.Framework
@@ -18,16 +19,24 @@
 
 	any = true;
 
-	var className = Overlap.HasFlag(flag) ? "overlap" : "";
+	var cssClassBuilder = new CssBuilder();
+
+	if (Overlap.HasFlag(flag))
+		cssClassBuilder.AddClass("overlap");
 
 	var desc = MetadataProvider.ResolveDescription(flag);
 	var moreInfoUrl = MetadataProvider.ResolveMoreInfoUrl(flag);
 
-	var style = string.IsNullOrWhiteSpace(desc) ? "" : "text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px; text-decoration-thickness: 1px; cursor: help;";
+	var style = "";
+	if (!string.IsNullOrWhiteSpace(desc))
+	{
+		cssClassBuilder.AddClass("popover-available-hint");
+		style = "cursor: help";
+	}
 
 	string flagName = flag.GetDisplayName() ?? flag.ToString();
 
-	<ExplanationPopover Content="@desc" Title="@flagName" Url="@moreInfoUrl" class="@className">
+	<ExplanationPopover Content="@desc" Title="@flagName" Url="@moreInfoUrl" class="@cssClassBuilder.Build()">
 		<span style="@style">@flagName</span>
 	</ExplanationPopover>
 }

--- a/Prolangle/Components/LanguageSelection.razor
+++ b/Prolangle/Components/LanguageSelection.razor
@@ -2,7 +2,8 @@
 @using Prolangle.Languages.Framework
 
 <div>
-    <BlazoredTypeahead SearchMethod="Search"
+	<BlazoredTypeahead SearchMethod="Search"
+	                   placeholder="Type the name of a language…"
                        TValue="ILanguage"
                        TItem="ILanguage"
                        ShowDropDownOnFocus="true"

--- a/Prolangle/Pages/Home.razor
+++ b/Prolangle/Pages/Home.razor
@@ -36,10 +36,8 @@ else
 		else
 		{
 			<span>
-				Some terms are
-				<span style="text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px; text-decoration-thickness: 1px;">underlined</span>.
-				You can tap or click those to get a quick explanation. Or, head to
-				<NavLink href="/explanations">Explanations</NavLink> for more info.
+				Some terms are <span class="popover-available-hint">underlined</span>. You can tap or click those to get
+				a quick explanation. Or, head to <NavLink href="/explanations">Explanations</NavLink> for more info.
 			</span>
 		}
 	</p>

--- a/Prolangle/Pages/Home.razor
+++ b/Prolangle/Pages/Home.razor
@@ -23,6 +23,26 @@
 else
 {
 	<LanguageSelection AvailableLanguages="@AvailableLanguages" OnLanguageSelected="@OnLanguageSelected"/>
+
+	<p>
+		<Icon Name="IconName.Lightbulb" Padding="Padding.Is2" />
+		@if (guessCount == 0)
+		{
+			<span>
+				Lost? Just try picking a language, or head to <NavLink href="/explanations">Explanations</NavLink>
+				for more info.
+			</span>
+		}
+		else
+		{
+			<span>
+				Some terms are
+				<span style="text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px; text-decoration-thickness: 1px;">underlined</span>.
+				You can tap or click those to get a quick explanation. Or, head to
+				<NavLink href="/explanations">Explanations</NavLink> for more info.
+			</span>
+		}
+	</p>
 }
 
 @code {
@@ -30,10 +50,15 @@ else
 	private List<ILanguage> AvailableLanguages => LanguagesProvider!.Languages.Where(l => !RevealedLanguages.Contains(l)).ToList();
 	private List<ILanguage> RevealedLanguages { get; } = [];
 	private ILanguage TargetLanguage => GuessGame!.MetadatumGameLanguage;
+
+	// revisit these fields once #22 is resolved
+	private int guessCount;
 	private bool won;
 
 	private void OnLanguageSelected(ILanguage language)
 	{
+		guessCount++;
+
 		RevealedLanguages.Add(language);
 
 		var result = GuessGame!.MetadatumGameLanguage.Id == language.Id;

--- a/Prolangle/wwwroot/css/app.css
+++ b/Prolangle/wwwroot/css/app.css
@@ -4,3 +4,10 @@
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
+
+.popover-available-hint {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+}


### PR DESCRIPTION
- makes the search field (which isn't necessarily recognizable as such) more discoverable by adding a placeholder text
- adds a footnote to give you more hints. If you haven't tried at all, encourages you to try (or look at /explanations). If you've tried at least once, it also points out the dotted underlines. If you've won, it disappears.

This is technically ready, but I'm OK with adding polish in visuals and wording before we merge.