### PR TITLE
Explain most paradigms; clean up Explanations page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # _Waiting for deployment_
 
 * The language selection shows a clearer message if you've previously tried the same one before https://github.com/ricardoboss/Prolangle/pull/132 
+* Lots more language paradigms have been explained https://github.com/ricardoboss/Prolangle/pull/127
 
 # 2024-09-04.2
 

--- a/Prolangle/Components/ExplanationBodyText.razor
+++ b/Prolangle/Components/ExplanationBodyText.razor
@@ -15,7 +15,7 @@
 			@flagName
 		</Heading>
 
-		<Paragraph Margin="Margin.Is3.FromStart">
+		<Paragraph Margin="Margin.Is3.FromStart" style="max-width: 80ch">
 			@if (!string.IsNullOrWhiteSpace(desc))
 			{
 				@desc

--- a/Prolangle/Components/ExplanationSection.razor
+++ b/Prolangle/Components/ExplanationSection.razor
@@ -1,6 +1,6 @@
 @using Prolangle.Pages
 
-<Heading Size="@Size" id="@Id" class="page-section">
+<Heading Size="@Size" id="@Id" class="page-section" Style="@(IsFirst ? "" : "margin-top: 2.5em")">
 	@ChildContent
 </Heading>
 
@@ -11,6 +11,9 @@
 
 	[Parameter]
 	public required string Id { get; set; }
+
+	[Parameter]
+    public required bool IsFirst { get; set; }
 
 	[CascadingParameter]
 	public Explanations? ExplanationsPage { get; set; }

--- a/Prolangle/Components/ShareMetadatumComparisonButton.razor
+++ b/Prolangle/Components/ShareMetadatumComparisonButton.razor
@@ -1,5 +1,6 @@
 @using Prolangle.Languages.Framework
 @using System.Text
+@using Humanizer
 @using Prolangle.Models
 @using Prolangle.Services
 @inject IJSRuntime JsRuntime
@@ -27,7 +28,7 @@
 	private async Task OnClicked()
 	{
 		var comparisons = GetComparisonResults();
-		var shareContent = $"Found today's #prolangle language in {RevealedLanguages.Count} attempts!\n\n{comparisons}\nTry it yourself at https://prolangle.ricardoboss.de";
+		var shareContent = $"Found today's #prolangle language in {"attempt".ToQuantity(RevealedLanguages.Count)}!\n\n{comparisons}\nTry it yourself at https://prolangle.ricardoboss.de";
 
 		snackbarMessage = await JsRuntime!.InvokeAsync<string>("shareResult", shareContent);
 

--- a/Prolangle/Languages/CSharp.cs
+++ b/Prolangle/Languages/CSharp.cs
@@ -27,8 +27,7 @@ public class CSharp : BaseLanguage
 
 	public override Paradigms Paradigms { get; } = Paradigms.ObjectOriented | Paradigms.Functional |
 	                                               Paradigms.Structured | Paradigms.Imperative | Paradigms.Generic |
-	                                               Paradigms.Reflective | Paradigms.EventDriven | Paradigms.TaskDriven |
-	                                               Paradigms.Concurrent;
+	                                               Paradigms.Reflective | Paradigms.EventDriven | Paradigms.Concurrent;
 
 	public override double? TiobeRating { get; } = 7.3;
 	public override int AppearanceYear { get; } = 2000;

--- a/Prolangle/Languages/Framework/Paradigms.cs
+++ b/Prolangle/Languages/Framework/Paradigms.cs
@@ -56,35 +56,32 @@ public enum Paradigms
 	             "iterate over them.")]
 	Reflective = 1 << 8,
 
-	[Display(Name = "Task-driven")]
-	TaskDriven = 1 << 9,
-
 	[Description("A concurrent language offers strong language-level support " +
 	             "for calls to run concurrently, i.e., for them to overlap " +
 	             "each other, and still succeed safely.")]
-	Concurrent = 1 << 10,
+	Concurrent = 1 << 9,
 
 	[Display(Name = "Natural language")]
 	[Description("In a natural programming language, the syntax is heavily " +
 	             "inspired by 'natural languages', i.e. languages such as " +
 	             "English that humans use to communicate with each other.")]
-	NaturalLanguage = 1 << 11,
+	NaturalLanguage = 1 << 10,
 
 	[Display(Name = "Object-based")]
 	[Description("An object-based language is similar to an object-oriented " +
 	             "language, but does not support the full feature set " +
 	             "generally expected from OOP. For example, it may lack " +
 	             "implementation inheritance.")]
-	ObjectBased = 1 << 12,
+	ObjectBased = 1 << 11,
 
 	[Display(Name = "Block-based")]
 	[Description("A block-based language is one in which the program is " +
 	             "constructed by dragging blocks around, rather than typing " +
 	             "text. This is a form of visual programming.")]
-	BlockBased = 1 << 13,
+	BlockBased = 1 << 12,
 
 	[Description("An esoteric language isn't meant to be used in production " +
 	             "code, but was rather designed as a proof of concept, or as a " +
 	             "joke.")]
-	Esoteric = 1 << 14
+	Esoteric = 1 << 13
 }

--- a/Prolangle/Languages/Framework/Paradigms.cs
+++ b/Prolangle/Languages/Framework/Paradigms.cs
@@ -11,24 +11,63 @@ public enum Paradigms
 	[Display(Name = "Object-oriented")]
 	ObjectOriented = 1 << 0,
 
+	[Description("Functional languages focus on applying and composing " +
+	             "functions. Often, a focus is put on making these as pure " +
+	             "(side-effect-free) as possible.")]
 	Functional = 1 << 1,
+
+	[Description("In generic programming, code can be written against a " +
+	             "template of a type, rather than a concrete type, and can " +
+	             "then be applied to multiple concrete types.")]
 	Generic = 1 << 2,
+
+	[Description("Imperative programming focuses on statements, which define " +
+	             "what a program does as a step-by-step recipe.")]
 	Imperative = 1 << 3,
+
+	[Description("Structured programming is a form of imperative programming " +
+	             "that introduces conditions (if/then/else), loops (while, " +
+	             "for) and subroutines (other functions or methods to " +
+	             "be called), and organizes those in so-called blocks.")]
 	Structured = 1 << 4,
+
+	[Description("Procedural programming is a form of imperative programming " +
+	             "that focuses on procedures. Depending on the context, " +
+	             "these may also be referred to as functions, methods, or " +
+	             "subroutines).")]
 	Procedural = 1 << 5,
+
+	[Description("In declarative programming, you focus on the abstract " +
+	             "desired result rather than the concrete control flow (e.g.," +
+	             "series of steps) that would lead to it.")]
 	Declarative = 1 << 6,
 
 	[Display(Name = "Event-driven")]
+	[Description("Event-driven languages provide high-level facilities to " +
+	             "react to external inputs, such as key presses and mouse " +
+	             "clicks, or incoming network data.")]
 	EventDriven = 1 << 7,
 
+	[Description("Reflective programming is a form of metaprogramming where " +
+	             "a running program can 'reflect on itself', i.e. know and " +
+	             "possibly modify its own structure and behavior. For " +
+	             "example, a reflective programming language may be able to " +
+	             "ask itself, 'which types currently exist?', and to " +
+	             "iterate over them.")]
 	Reflective = 1 << 8,
 
 	[Display(Name = "Task-driven")]
 	TaskDriven = 1 << 9,
 
+	[Description("A concurrent language offers strong language-level support " +
+	             "for calls to run concurrently, i.e., for them to overlap " +
+	             "each other, and still succeed safely.")]
 	Concurrent = 1 << 10,
 
 	[Display(Name = "Natural language")]
+	[Description("In a natural programming language, the syntax is heavily " +
+	             "inspired by 'natural languages', i.e. languages such as " +
+	             "English that humans use to communicate with each other.")]
 	NaturalLanguage = 1 << 11,
 
 	[Display(Name = "Object-based")]

--- a/Prolangle/Pages/Explanations.razor
+++ b/Prolangle/Pages/Explanations.razor
@@ -27,7 +27,7 @@
 
 				<Column ColumnSize="ColumnSize.Is10">
 					<Div>
-						<ExplanationSection Size="HeadingSize.Is4" Id="applications">Known for building / Applications</ExplanationSection>
+						<ExplanationSection IsFirst="true" Size="HeadingSize.Is4" Id="applications">Known for building / Applications</ExplanationSection>
 
 						@foreach (Applications application in Enum.GetValues<Applications>()
 							          .Except([Applications.None, Applications.Other])

--- a/Prolangle/Pages/Explanations.razor
+++ b/Prolangle/Pages/Explanations.razor
@@ -50,6 +50,14 @@
 						{
 							<ExplanationBodyText Value="@typeSystem"/>
 						}
+
+						<ExplanationSection Size="HeadingSize.Is4" Id="paradigms">Paradigms</ExplanationSection>
+
+						@foreach (Paradigms paradigm in Enum.GetValues<Paradigms>()
+							          .OrderBy(t => t.ToString()))
+						{
+							<ExplanationBodyText Value="@paradigm"/>
+						}
 					</Div>
 				</Column>
 			</Row>

--- a/Prolangle/Pages/Explanations.razor
+++ b/Prolangle/Pages/Explanations.razor
@@ -30,6 +30,7 @@
 						<ExplanationSection Size="HeadingSize.Is4" Id="applications">Known for building / Applications</ExplanationSection>
 
 						@foreach (Applications application in Enum.GetValues<Applications>()
+							          .Except([Applications.None, Applications.Other])
 							          .OrderBy(t => t.ToString()))
 						{
 							<ExplanationBodyText Value="@application"/>
@@ -38,6 +39,7 @@
 						<ExplanationSection Size="HeadingSize.Is4" Id="syntax-styles">Syntax styles</ExplanationSection>
 
 						@foreach (SyntaxStyle syntaxStyle in Enum.GetValues<SyntaxStyle>()
+							          .Except([SyntaxStyle.None, SyntaxStyle.Other])
 							          .OrderBy(t => t.ToString()))
 						{
 							<ExplanationBodyText Value="@syntaxStyle"/>
@@ -46,6 +48,7 @@
 						<ExplanationSection Size="HeadingSize.Is4" Id="type-systems">Type systems</ExplanationSection>
 
 						@foreach (TypeSystem typeSystem in Enum.GetValues<TypeSystem>()
+							          .Except([TypeSystem.None, TypeSystem.Other])
 							          .OrderBy(t => t.ToString()))
 						{
 							<ExplanationBodyText Value="@typeSystem"/>
@@ -54,6 +57,7 @@
 						<ExplanationSection Size="HeadingSize.Is4" Id="paradigms">Paradigms</ExplanationSection>
 
 						@foreach (Paradigms paradigm in Enum.GetValues<Paradigms>()
+							          .Except([Paradigms.None])
 							          .OrderBy(t => t.ToString()))
 						{
 							<ExplanationBodyText Value="@paradigm"/>


### PR DESCRIPTION
A few more remarks:

- I propose getting rid of `TaskDriven`. Wikipedia just links to https://en.wikipedia.org/w/index.php?title=The_Task-based_Asynchronous_Pattern&redirect=no, which is barely an article, and describes more an API than a language feature. C# is already marked concurrent.
- I'm still not sure how to make the explanations page pop. I was wondering if we need to parse Markdown or HTML in `[Description]`; that might help. The layout is overall still too wide and too sparse, I think.
- I'm struggling to explain OOP. :-) A lot of explanations talk about classes, but not all OOP classes have those.