### PR TITLE
added Bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The snippets game has been made harder. Previously, you saw 10% of the code, and each guess gave you another 10%.
 Now, you initially see just 3%, and each guess gives you 5%.
 * Added the Smalltalk language https://github.com/ricardoboss/Prolangle/pull/136
+* Added the Bash language https://github.com/ricardoboss/Prolangle/pull/131
 
 # 2024-09-04.2
 

--- a/Prolangle.Tests/GuessGameTests.cs
+++ b/Prolangle.Tests/GuessGameTests.cs
@@ -24,8 +24,8 @@ public class GuessGameTests
 	private LanguagesProvider LanguagesProvider { get; }
 
 	[Theory]
-	[InlineData(1_000, "C", "Brainfuck")]
-	[InlineData(1_234, "JavaScript", "Dart")]
+	[InlineData(1_000, "Brainfuck", "Brainfuck")]
+	[InlineData(1_234, "Java", "Dart")]
 	public void TestLanguages(int seed, string expectedMetadatumGameLanguage, string expectedSnippetGameLanguage)
 	{
 		var seeder = new GameSeeder(() => seed, DateTime.MinValue, DateTime.MinValue);

--- a/Prolangle/Languages/Bash.cs
+++ b/Prolangle/Languages/Bash.cs
@@ -1,0 +1,31 @@
+using Prolangle.Languages.Framework;
+
+namespace Prolangle.Languages;
+
+public class Bash : BaseLanguage
+{
+	private Bash()
+	{
+	}
+
+	public static Bash Instance { get; } = new();
+
+	public override Guid Id { get; } = Guid.NewGuid();
+	public override string Name { get; } = "Bash";
+
+	public override TypeSystem Typing { get; } =
+		TypeSystem.Weak | TypeSystem.Dynamic;
+
+	public override bool Compiled { get; } = false;
+	public override MemoryManagement MemoryManagement { get; } = MemoryManagement.TracingGarbageCollection;
+	public override SyntaxStyle SyntaxStyle { get; } = SyntaxStyle.Other;
+
+	public override Applications KnownForBuilding { get; } =
+		Applications.Scripts;
+
+	public override Paradigms Paradigms { get; } = Paradigms.Imperative | Paradigms.Procedural |
+	                                               Paradigms.Reflective;
+
+	public override double? TiobeRating { get; } = 0.21;
+	public override int AppearanceYear { get; } = 1989;
+}

--- a/Prolangle/Languages/Bash.cs
+++ b/Prolangle/Languages/Bash.cs
@@ -17,7 +17,7 @@ public class Bash : BaseLanguage
 		TypeSystem.Weak | TypeSystem.Dynamic;
 
 	public override bool Compiled { get; } = false;
-	public override MemoryManagement MemoryManagement { get; } = MemoryManagement.TracingGarbageCollection;
+	public override MemoryManagement MemoryManagement { get; } = MemoryManagement.None;
 	public override SyntaxStyle SyntaxStyle { get; } = SyntaxStyle.Other;
 
 	public override Applications KnownForBuilding { get; } =

--- a/Prolangle/Services/LanguagesProvider.cs
+++ b/Prolangle/Services/LanguagesProvider.cs
@@ -16,6 +16,7 @@ public class LanguagesProvider
 		{
 			yield return AppleScript.Instance;
 			yield return Assembly.Instance;
+			yield return Bash.Instance;
 			yield return Basic.Instance;
 			yield return Brainfuck.Instance;
 			yield return C.Instance;


### PR DESCRIPTION
This part:

```
	public override MemoryManagement MemoryManagement { get; } = MemoryManagement.TracingGarbageCollection;
```

is debatable. It doesn't have a tracing GC per se; it simply doesn't really have a notion of references, so values can get cleaned up as they disappear. Maybe `Other` would be better, or maybe we need a new value `Simple`?