### PR TITLE
Minor explanations page improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * The language selection shows a clearer message if you've previously tried the same one before https://github.com/ricardoboss/Prolangle/pull/132 
 * Lots more language paradigms have been explained https://github.com/ricardoboss/Prolangle/pull/127
+* Memory management is now also on the Explanations page https://github.com/ricardoboss/Prolangle/pull/145
 * The snippets game has been made harder. Previously, you saw 10% of the code, and each guess gave you another 10%.
 Now, you initially see just 3%, and each guess gives you 5%.
 * Added the Smalltalk language https://github.com/ricardoboss/Prolangle/pull/136

--- a/Prolangle/Components/Toc.razor
+++ b/Prolangle/Components/Toc.razor
@@ -18,6 +18,10 @@
 		color: var(--color-secondary);
 	}
 
+	li.toc-item {
+		margin-bottom: 0.5em;
+	}
+
 	li.toc-item a:link, li.toc-item a:visited, li.toc-item a:hover, li.toc-item a:active {
       color: var(--color-secondary);
     }

--- a/Prolangle/Languages/Framework/MemoryManagement.cs
+++ b/Prolangle/Languages/Framework/MemoryManagement.cs
@@ -5,7 +5,13 @@ namespace Prolangle.Languages.Framework;
 
 public enum MemoryManagement
 {
+	[Description("""
+                 In some languages, you cannot manage memory at all. For
+                 example, this can mean that all variables are always in the
+                 stack, not the heap.
+                 """)]
 	None,
+
 	Other,
 
 	[Display(Name = "Tracing garbage collection")]

--- a/Prolangle/Pages/Explanations.razor
+++ b/Prolangle/Pages/Explanations.razor
@@ -36,6 +36,15 @@
 							<ExplanationBodyText Value="@typeSystem"/>
 						}
 
+						<ExplanationSection Size="HeadingSize.Is4" Id="memory-management">Memory management</ExplanationSection>
+
+						@foreach (MemoryManagement memoryManagement in Enum.GetValues<MemoryManagement>()
+							          .Except([MemoryManagement.Other])
+							          .OrderBy(t => t.ToString()))
+						{
+							<ExplanationBodyText Value="@memoryManagement"/>
+						}
+
 						<ExplanationSection Size="HeadingSize.Is4" Id="syntax-styles">Syntax styles</ExplanationSection>
 
 						@foreach (SyntaxStyle syntaxStyle in Enum.GetValues<SyntaxStyle>()

--- a/Prolangle/Pages/Explanations.razor
+++ b/Prolangle/Pages/Explanations.razor
@@ -27,13 +27,13 @@
 
 				<Column ColumnSize="ColumnSize.Is10">
 					<Div>
-						<ExplanationSection IsFirst="true" Size="HeadingSize.Is4" Id="applications">Known for building / Applications</ExplanationSection>
+						<ExplanationSection IsFirst="true" Size="HeadingSize.Is4" Id="type-systems">Type systems</ExplanationSection>
 
-						@foreach (Applications application in Enum.GetValues<Applications>()
-							          .Except([Applications.None, Applications.Other])
+						@foreach (TypeSystem typeSystem in Enum.GetValues<TypeSystem>()
+							          .Except([TypeSystem.None, TypeSystem.Other])
 							          .OrderBy(t => t.ToString()))
 						{
-							<ExplanationBodyText Value="@application"/>
+							<ExplanationBodyText Value="@typeSystem"/>
 						}
 
 						<ExplanationSection Size="HeadingSize.Is4" Id="syntax-styles">Syntax styles</ExplanationSection>
@@ -45,13 +45,13 @@
 							<ExplanationBodyText Value="@syntaxStyle"/>
 						}
 
-						<ExplanationSection Size="HeadingSize.Is4" Id="type-systems">Type systems</ExplanationSection>
+						<ExplanationSection Size="HeadingSize.Is4" Id="applications">Known for building / Applications</ExplanationSection>
 
-						@foreach (TypeSystem typeSystem in Enum.GetValues<TypeSystem>()
-							          .Except([TypeSystem.None, TypeSystem.Other])
+						@foreach (Applications application in Enum.GetValues<Applications>()
+							          .Except([Applications.None, Applications.Other])
 							          .OrderBy(t => t.ToString()))
 						{
-							<ExplanationBodyText Value="@typeSystem"/>
+							<ExplanationBodyText Value="@application"/>
 						}
 
 						<ExplanationSection Size="HeadingSize.Is4" Id="paradigms">Paradigms</ExplanationSection>


### PR DESCRIPTION
- the TOC order now matches that in the properties game
- we now also explain memory management
- added a description for `MemoryManagement.None` (I hope this one makes sense?)
- made the sections in the TOC a little easier to distinguish