### PR TITLE
Upgrade dependencies

### DIFF
--- a/Prolangle.Tests/Prolangle.Tests.csproj
+++ b/Prolangle.Tests/Prolangle.Tests.csproj
@@ -10,15 +10,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-        <PackageReference Include="xunit" Version="2.7.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.1">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Prolangle/Pages/Explanations.razor.cs
+++ b/Prolangle/Pages/Explanations.razor.cs
@@ -36,7 +36,7 @@ public partial class Explanations : ComponentBase, IAsyncDisposable
 		{
 			_scrollSpy.ScrollSectionSectionCentered += ScrollSpy_ScrollSectionSectionCentered;
 
-			await _scrollSpy.StartSpying("page-section");
+			await _scrollSpy.StartSpying(containerSelector: "html", sectionClassSelector: "page-section");
 		}
 	}
 

--- a/Prolangle/Prolangle.csproj
+++ b/Prolangle/Prolangle.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
     <PackageReference Include="MudBlazor" Version="7.8.0" />
   </ItemGroup>
 

--- a/Prolangle/Prolangle.csproj
+++ b/Prolangle/Prolangle.csproj
@@ -10,13 +10,14 @@
   <ItemGroup>
     <PackageReference Include="BlazorComponentUtilities" Version="1.8.0" />
     <PackageReference Include="Blazored.Typeahead" Version="4.7.0" />
-    <PackageReference Include="Blazorise.Bulma" Version="1.4.2" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.4.2" />
-    <PackageReference Include="Blazorise.Snackbar" Version="1.4.2" />
+    <PackageReference Include="Blazorise.Bulma" Version="1.6.1" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.6.1" />
+    <PackageReference Include="Blazorise.Snackbar" Version="1.6.1" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.2" PrivateAssets="all" />
-    <PackageReference Include="MudBlazor" Version="6.17.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
+    <PackageReference Include="MudBlazor" Version="7.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrades all NuGet packages that had updates.

All tests pass. The only issue I noticed is that `ScrollSpy` now takes two args instead of one.

(edit) Found an issue. The icons no longer match. Is that a caching thing?

![image](https://github.com/user-attachments/assets/02f57deb-96c9-4080-8ac8-39104f754272)
