### PR TITLE
LanguageSelection: only submit value if it isn't `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Now, you initially see just 3%, and each guess gives you 5%.
 * Added the Smalltalk language https://github.com/ricardoboss/Prolangle/pull/136
 * After having won the code snippets game, you're now shown the file name, attribution, and license, if we didn't 
 write it ourselves.
+* Fixed an error that sometimes occurred after selecting a language https://github.com/ricardoboss/Prolangle/pull/147
 
 # 2024-09-04.2
 

--- a/Prolangle/Components/LanguageSelection.razor
+++ b/Prolangle/Components/LanguageSelection.razor
@@ -61,6 +61,9 @@
 
 	private async Task Guess()
 	{
+		if (SelectedLanguage is null)
+			return;
+
 		await OnLanguageSelected.InvokeAsync(SelectedLanguage);
 
 		SelectedLanguage = null;


### PR DESCRIPTION
This fixes an NRE.

Without this PR, you can type something into the picker, click 'Guess', and get an NRE.

I'm not entirely happy with this, though. I think I made a mistake with #119. Before that, we didn't use data binding, and we could (probably?) let the user just type in a language and hit enter. Now, you have to pick from the menu (even if you've typed the value).

Thoughts?